### PR TITLE
Fix FlarumDataSource timeline

### DIFF
--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -75,9 +75,11 @@ class FlarumDataSource extends DataSource
 
         $this->resolveAuthenticatedUser($request);
 
-        $request->timelineData = $this->timeline->finalize($request->time);
-
         $this->timeline->event('Clockwork')->end();
+
+        $this->timeline->finalize($request->time);
+
+        $request->timeline()->merge($this->timeline);
 
         return $request;
     }
@@ -110,7 +112,7 @@ class FlarumDataSource extends DataSource
     public function listenToEvents()
     {
         $this->container['events']->listen('clockwork.controller.start', function () {
-            $this->timeline->event('Request processing')->start();
+            $this->timeline->event('Request processing')->begin();
         });
 
         $this->container['events']->listen('clockwork.controller.end', function () {
@@ -127,12 +129,12 @@ class FlarumDataSource extends DataSource
      */
     public function listenToEarlyEvents()
     {
-        $this->timeline->event('Total execution time')->start();
-        $this->timeline->event('Application booting')->start();
+        $this->timeline->event('Total execution time')->begin();
+        $this->timeline->event('Application booting')->begin();
 
         $this->container['flarum']->booted(function () {
             $this->timeline->event('Application booting')->end();
-            $this->timeline->event('Application running')->start();
+            $this->timeline->event('Application running')->begin();
         });
 
         $this->count = [];
@@ -175,7 +177,7 @@ class FlarumDataSource extends DataSource
     public function addDocumentData(?Document $document = null)
     {
         $this->timeline->event('Request processing')->end();
-        $this->timeline->event('Clockwork')->start();
+        $this->timeline->event('Clockwork')->begin();
 
         /**
          * @var UserData

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Fixes the timeline events, I didn't notice last time that the way the timeline data is merged was changed.
* Uses `begin()` instead of `start()` to register the exact time the event begins.
