### PR TITLE
Add a couple more timeline events and tweak event start time

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -24,9 +24,6 @@ return [
     (new Extend\Frontend('admin'))
         ->content(AddFrontendData::class),
 
-    (new Extend\ApiController(\Flarum\Api\Controller\AbstractSerializeController::class))
-        ->prepareDataQuery(AddFrontendData::class),
-
     (new Extend\Routes('forum'))
         ->get('/__clockwork[/]', 'fof.clockwork.app', Controllers\ClockworkRedirectController::class)
         ->get('/__clockwork/app', 'fof.clockwork.app.web', Controllers\ClockworkWebController::class)

--- a/extend.php
+++ b/extend.php
@@ -12,6 +12,7 @@
 namespace FoF\Clockwork;
 
 use Flarum\Extend;
+use Flarum\Http\Middleware\StartSession;
 use FoF\Clockwork\Extend\FileStoragePath;
 
 return [
@@ -37,11 +38,11 @@ return [
         ->register(ClockworkServiceProvider::class),
 
     (new Extend\Middleware('forum'))
-        ->add(Middleware\ClockworkMiddleware::class),
+        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
 
     (new Extend\Middleware('admin'))
-        ->add(Middleware\ClockworkMiddleware::class),
+        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
 
     (new Extend\Middleware('api'))
-        ->add(Middleware\ClockworkMiddleware::class),
+        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
 ];

--- a/extend.php
+++ b/extend.php
@@ -12,7 +12,6 @@
 namespace FoF\Clockwork;
 
 use Flarum\Extend;
-use Flarum\Http\Middleware\StartSession;
 use FoF\Clockwork\Extend\FileStoragePath;
 
 return [
@@ -35,11 +34,11 @@ return [
         ->register(ClockworkServiceProvider::class),
 
     (new Extend\Middleware('forum'))
-        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
+        ->add(Middleware\ClockworkMiddleware::class),
 
     (new Extend\Middleware('admin'))
-        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
+        ->add(Middleware\ClockworkMiddleware::class),
 
     (new Extend\Middleware('api'))
-        ->insertAfter(StartSession::class, Middleware\ClockworkMiddleware::class),
+        ->add(Middleware\ClockworkMiddleware::class),
 ];

--- a/extend.php
+++ b/extend.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -117,6 +117,11 @@ class FlarumDataSource extends DataSource
 
         $this->container['events']->listen('clockwork.controller.end', function () {
             $this->timeline->event('Request processing')->end();
+
+            if ($this->timeline->find('Clockwork') === null) {
+                $this->timeline->event('Clockwork')->begin();
+                $this->addDocumentData();
+            }
         });
 
         $this->container['events']->listen('clockwork.running.end', function () {

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -17,6 +17,7 @@ use Clockwork\Request\Log;
 use Clockwork\Request\Request;
 use Clockwork\Request\Timeline\Timeline;
 use Clockwork\Request\UserData;
+use Flarum\Api\Controller\AbstractSerializeController;
 use Flarum\Foundation\Application;
 use Flarum\Frontend\Document;
 use Illuminate\Contracts\Container\Container;
@@ -116,6 +117,7 @@ class FlarumDataSource extends DataSource
         });
 
         $this->container['events']->listen('clockwork.controller.end', function () {
+            $this->timeline->event('Data serialization')->end();
             $this->timeline->event('Request processing')->end();
 
             if ($this->timeline->find('Clockwork') === null) {
@@ -148,6 +150,15 @@ class FlarumDataSource extends DataSource
             $str = is_string($event) ? $event : get_class($event);
             $this->count[$str] = Arr::get($this->count, $str) ?? 0;
             $this->count[$str]++;
+        });
+
+        AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {
+            $this->timeline->event('Controller logic')->begin();
+        });
+
+        AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {
+            $this->timeline->event('Controller logic')->end();
+            $this->timeline->event('Data serialization')->begin();
         });
     }
 

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -159,7 +159,7 @@ class FlarumDataSource extends DataSource
             $this->count[$str]++;
         });
 
-        AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {
+        AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function () {
             $this->timeline->event('Controller logic')->end();
             $this->timeline->event('Data serialization')->color('purple')->begin();
         });

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -112,12 +112,19 @@ class FlarumDataSource extends DataSource
      */
     public function listenToEvents()
     {
-        $this->container['events']->listen('clockwork.controller.start', function () {
+        $this->container['events']->listen('clockwork.middleware.start', function () {
             $this->timeline->event('Request processing')->begin();
+        });
+
+        $this->container['events']->listen('clockwork.controller.start', function () {
+            $this->timeline->event('Controller logic')->begin();
         });
 
         $this->container['events']->listen('clockwork.controller.end', function () {
             $this->timeline->event('Data serialization')->end();
+        });
+
+        $this->container['events']->listen('clockwork.middleware.end', function () {
             $this->timeline->event('Request processing')->end();
 
             if ($this->timeline->find('Clockwork') === null) {
@@ -150,10 +157,6 @@ class FlarumDataSource extends DataSource
             $str = is_string($event) ? $event : get_class($event);
             $this->count[$str] = Arr::get($this->count, $str) ?? 0;
             $this->count[$str]++;
-        });
-
-        AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {
-            $this->timeline->event('Controller logic')->begin();
         });
 
         AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -113,11 +113,11 @@ class FlarumDataSource extends DataSource
     public function listenToEvents()
     {
         $this->container['events']->listen('clockwork.middleware.start', function () {
-            $this->timeline->event('Request processing')->begin();
+            $this->timeline->event('Request processing')->color('purple')->begin();
         });
 
         $this->container['events']->listen('clockwork.controller.start', function () {
-            $this->timeline->event('Controller logic')->begin();
+            $this->timeline->event('Controller logic')->color('purple')->begin();
         });
 
         $this->container['events']->listen('clockwork.controller.end', function () {
@@ -148,7 +148,7 @@ class FlarumDataSource extends DataSource
 
         $this->container['flarum']->booted(function () {
             $this->timeline->event('Application booting')->end();
-            $this->timeline->event('Application running')->begin();
+            $this->timeline->event('Application running')->color('green')->begin();
         });
 
         $this->count = [];
@@ -161,7 +161,7 @@ class FlarumDataSource extends DataSource
 
         AbstractSerializeController::addSerializationPreparationCallback(AbstractSerializeController::class, function() {
             $this->timeline->event('Controller logic')->end();
-            $this->timeline->event('Data serialization')->begin();
+            $this->timeline->event('Data serialization')->color('purple')->begin();
         });
     }
 

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -192,7 +192,6 @@ class FlarumDataSource extends DataSource
 
     public function addDocumentData(?Document $document = null)
     {
-        $this->timeline->event('Request processing')->end();
         $this->timeline->event('Clockwork')->begin();
 
         /**

--- a/src/ClockworkServiceProvider.php
+++ b/src/ClockworkServiceProvider.php
@@ -22,7 +22,7 @@ use Clockwork\Support\Vanilla\Clockwork;
 use Flarum\Group\Group;
 use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
-use FoF\Clockwork\Middleware\BeforeRouteExecutionMiddelware;
+use FoF\Clockwork\Middleware\BeforeRouteExecutionMiddleware;
 use Illuminate\Support\ServiceProvider;
 
 class ClockworkServiceProvider extends ServiceProvider
@@ -42,7 +42,7 @@ class ClockworkServiceProvider extends ServiceProvider
         // and after all middleware, including extension middleware.
         foreach (['admin', 'forum', 'api'] as $frontend) {
             $this->app->extend("flarum.$frontend.middleware", function ($middleware) {
-                $middleware[] = BeforeRouteExecutionMiddelware::class;
+                $middleware[] = BeforeRouteExecutionMiddleware::class;
 
                 return $middleware;
             });

--- a/src/ClockworkServiceProvider.php
+++ b/src/ClockworkServiceProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ClockworkServiceProvider.php
+++ b/src/ClockworkServiceProvider.php
@@ -22,6 +22,7 @@ use Clockwork\Support\Vanilla\Clockwork;
 use Flarum\Group\Group;
 use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
+use FoF\Clockwork\Middleware\BeforeRouteExecutionMiddelware;
 use Illuminate\Support\ServiceProvider;
 
 class ClockworkServiceProvider extends ServiceProvider
@@ -36,6 +37,16 @@ class ClockworkServiceProvider extends ServiceProvider
         $this->app['clockwork.cache']->listenToEvents();
         $this->app['clockwork.flarum']->listenToEvents();
         $this->app['clockwork.events']->listenToEvents();
+
+        // This is done to dispatch an event right before controller execution,
+        // and after all middleware, including extension middleware.
+        foreach (['admin', 'forum', 'api'] as $frontend) {
+            $this->app->extend("flarum.$frontend.middleware", function ($middleware) {
+                $middleware[] = BeforeRouteExecutionMiddelware::class;
+
+                return $middleware;
+            });
+        }
     }
 
     public function register()

--- a/src/Middleware/BeforeRouteExecutionMiddleware.php
+++ b/src/Middleware/BeforeRouteExecutionMiddleware.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class BeforeRouteExecutionMiddelware implements MiddlewareInterface
+class BeforeRouteExecutionMiddleware implements MiddlewareInterface
 {
     /**
      * @var Container

--- a/src/Middleware/BeforeRouteExecutionMiddleware.php
+++ b/src/Middleware/BeforeRouteExecutionMiddleware.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class ClockworkMiddleware implements MiddlewareInterface
+class BeforeRouteExecutionMiddelware implements MiddlewareInterface
 {
     /**
      * @var Container
@@ -42,32 +42,12 @@ class ClockworkMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $this->container['events']->dispatch('clockwork.running.end');
-        $this->container['events']->dispatch('clockwork.middleware.start');
+        $this->container['events']->dispatch('clockwork.controller.start');
 
         $response = $handler->handle($request);
 
-        $this->container['events']->dispatch('clockwork.middleware.end');
+        $this->container['events']->dispatch('clockwork.controller.end');
 
-        $requestHandler = $request->getAttribute('request-handler');
-        $uri = $request->getUri();
-
-        if ($requestHandler == 'flarum.api.middleware') {
-            $request = $request->withUri($uri->withPath('/api'.$uri->getPath()));
-        } elseif ($requestHandler == 'flarum.admin.middleware') {
-            $request = $request->withUri($uri->withPath('/admin'.$uri->getPath()));
-        }
-
-        $this->container['clockwork.flarum']
-            ->setRequest($request)
-            ->setResponse($response);
-
-        if (!$this->container['clockwork.authenticator']->check($request)) {
-            return $response;
-        }
-
-        return $this->container['clockwork']
-            ->usePsrMessage($request, $response)
-            ->requestProcessed();
+        return $response;
     }
 }

--- a/src/Middleware/BeforeRouteExecutionMiddleware.php
+++ b/src/Middleware/BeforeRouteExecutionMiddleware.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Middleware/ClockworkMiddleware.php
+++ b/src/Middleware/ClockworkMiddleware.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/clockwork.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Adds Controller logic timeline event (by listening to `clockwork.controller.start`).
* Adds Data serialization timeline event (using a data serialization preparation callback).
* Removes workaround that added flarum data (version, php version ...etc) on api requests.
* Removes redundant Request processing event ending (it had no effect because the same event is later terminated in the process).
* Renames `clockwork.controller.start/end` to `clockwork.middleware.start/end` to separate the time when middleware is executed and the time when the controller is executed, this will be more useful because Flarum 1.0 will allow executing the `ClockworkMiddleware` much earlier.
* Adds a new middleware that is added through the service provider on boot, in order to make sure it is always the last middleware before route resolving (related to the point above this one).
* Uses different colors for timeline events.

**Screenshot**
![clockwork_screenshot](https://lh3.googleusercontent.com/-7ky45IK23XY/YHmsA1319yI/AAAAAAAAFXc/5Xy0oFRZXp0rSh645iAiz6YR_l1GfH8IwCLcBGAsYHQ/s16000/Screenshot%2Bfrom%2B2021-04-16%2B16-00-18.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.