### PR TITLE
fix: repetitive requests on forum frontend

### DIFF
--- a/src/Clockwork/FlarumAuthenticator.php
+++ b/src/Clockwork/FlarumAuthenticator.php
@@ -32,7 +32,7 @@ class FlarumAuthenticator implements AuthenticatorInterface
     {
         $user = RequestUtil::getActor($request);
 
-        return true;//!$user->isGuest() && $user->groups->contains($this->groupId);
+        return !$user->isGuest() && $user->groups->contains($this->groupId);
     }
 
     public function requires()

--- a/src/Clockwork/FlarumAuthenticator.php
+++ b/src/Clockwork/FlarumAuthenticator.php
@@ -32,7 +32,7 @@ class FlarumAuthenticator implements AuthenticatorInterface
     {
         $user = RequestUtil::getActor($request);
 
-        return !$user->isGuest() && $user->groups->contains($this->groupId);
+        return true;//!$user->isGuest() && $user->groups->contains($this->groupId);
     }
 
     public function requires()

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -114,9 +114,11 @@ class FlarumDataSource extends DataSource
     {
         $this->container['events']->listen('clockwork.middleware.start', function () {
             $this->timeline->event('Request processing')->color('purple')->begin();
+            $this->timeline->event('Middleware')->color('yellow')->begin();
         });
 
         $this->container['events']->listen('clockwork.controller.start', function () {
+            $this->timeline->event('Middleware')->end();
             $this->timeline->event('Controller logic')->color('purple')->begin();
         });
 

--- a/src/Middleware/ClockworkMiddleware.php
+++ b/src/Middleware/ClockworkMiddleware.php
@@ -56,6 +56,8 @@ class ClockworkMiddleware implements MiddlewareInterface
             $request = $request->withUri($uri->withPath('/api'.$uri->getPath()));
         } elseif ($requestHandler == 'flarum.admin.middleware') {
             $request = $request->withUri($uri->withPath('/admin'.$uri->getPath()));
+        } elseif ($requestHandler == 'flarum.forum.handler') {
+            $request = $request->withUri($uri->withPath('/forum'.$uri->getPath()));
         }
 
         $this->container['clockwork.flarum']

--- a/src/Provider/ClockworkServiceProvider.php
+++ b/src/Provider/ClockworkServiceProvider.php
@@ -24,6 +24,7 @@ use Flarum\Group\Group;
 use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
 use FoF\Clockwork\Middleware\BeforeRouteExecutionMiddleware;
+use FoF\Clockwork\Middleware\ClockworkMiddleware;
 use Illuminate\Support\ServiceProvider;
 
 class ClockworkServiceProvider extends ServiceProvider
@@ -48,6 +49,13 @@ class ClockworkServiceProvider extends ServiceProvider
                 return $middleware;
             });
         }
+
+        // Remove the clockwork middleware from API Client handling
+        $this->app->extend('flarum.api_client.exclude_middleware', function (array $exlusions) {
+            $exlusions[] = ClockworkMiddleware::class;
+
+            return $exlusions;
+        });
     }
 
     public function register()


### PR DESCRIPTION
**Changes proposed in this pull request:**
Fixes multiple logging of the requests directed to the forum frontend making debugging difficult.

**Reviewers should focus on:**
This was happening because when loading the forum page flarum runs inner API requests using its API client to get the list of discussions for example, and the clockwork middleware was running multiple times due to that.

**Screenshot**
Before | After
-- | --
![Screenshot from 2022-06-03 11-42-31](https://user-images.githubusercontent.com/20267363/171839398-f8bf0638-19eb-40b2-8902-4362cdc71324.png) | ![Screenshot from 2022-06-03 11-42-59](https://user-images.githubusercontent.com/20267363/171839414-66308a7c-17b6-4085-935b-f912dfe09dc1.png)

