### PR TITLE
fix: clockwork needs an update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "require": {
     "flarum/core": "^1.0.2",
-    "itsgoingd/clockwork": "^5.0.8"
+    "itsgoingd/clockwork": "5.1.5"
   },
   "authors": [
     {


### PR DESCRIPTION
Clockwork is only working with the fixed version `5.1.5` at the moment.